### PR TITLE
Run command in shell for windows

### DIFF
--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -9,16 +9,38 @@ const PACKAGE_MANAGER_TO_COMMAND: Record<PackageManagers, string> = {
   yarn2: "yarn dlx",
 };
 
+const selectPackageManagerCommand = (packageManager: PackageManagers): string =>
+  PACKAGE_MANAGER_TO_COMMAND[packageManager];
+
+const spawnPackageManagerScript = async (
+  packageManager: PackageManagers,
+  args: string[]
+) => {
+  const command = selectPackageManagerCommand(packageManager);
+
+  const [pm, ...rest] = command.split(" ");
+
+  await spawn(pm, [...rest, ...args], {
+    stdio: "inherit",
+    cwd: process.cwd(),
+    shell: true,
+  });
+};
+
 const automigrate = async ({
-  packageManager,
+  packageManager = "npm",
 }: {
   packageManager: PackageManagers;
 }) => {
-  const command = PACKAGE_MANAGER_TO_COMMAND[packageManager];
-  await spawn(command, ["@storybook/auto-config", "styling"], {
-    stdio: "inherit",
-    cwd: process.cwd(),
-  });
+  try {
+    await spawnPackageManagerScript(packageManager, [
+      "@storybook/auto-config",
+      "styling",
+    ]);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
 };
 
 export default automigrate;

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -2,25 +2,24 @@ import { spawn } from "child_process";
 
 type PackageManagers = "npm" | "pnpm" | "yarn1" | "yarn2";
 
-const PACKAGE_MANAGER_TO_COMMAND: Record<PackageManagers, string> = {
-  npm: "npx",
-  pnpm: "pnpm dlx",
-  yarn1: "npx",
-  yarn2: "yarn dlx",
+const PACKAGE_MANAGER_TO_COMMAND: Record<PackageManagers, string[]> = {
+  npm: ["npx"],
+  pnpm: ["pnpm", "dlx"],
+  yarn1: ["npx"],
+  yarn2: ["yarn", "dlx"],
 };
 
-const selectPackageManagerCommand = (packageManager: PackageManagers): string =>
-  PACKAGE_MANAGER_TO_COMMAND[packageManager];
+const selectPackageManagerCommand = (
+  packageManager: PackageManagers
+): string[] => PACKAGE_MANAGER_TO_COMMAND[packageManager];
 
 const spawnPackageManagerScript = async (
   packageManager: PackageManagers,
   args: string[]
 ) => {
-  const command = selectPackageManagerCommand(packageManager);
+  const [command, ...baseArgs] = selectPackageManagerCommand(packageManager);
 
-  const [pm, ...rest] = command.split(" ");
-
-  await spawn(pm, [...rest, ...args], {
+  await spawn(command, [...baseArgs, ...args], {
     stdio: "inherit",
     cwd: process.cwd(),
     shell: true,


### PR DESCRIPTION
Closes #7 

Windows can choke on `child_process.spawn` unless you set the `shell` option to true.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.5--canary.8.c9231b7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-styling-webpack@0.0.5--canary.8.c9231b7.0
  # or 
  yarn add @storybook/addon-styling-webpack@0.0.5--canary.8.c9231b7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
