### PR TITLE
hotfix: add commas in order to fix the editor warning when user copy/paste from doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Below are a few popular configurations for common styling tools to get you start
           "style-loader",
           "css-loader",
           {
-            loader: "sass-loader"
+            loader: "sass-loader",
             options: { implementation: require.resolve("sass") }
           },
         ],
@@ -170,7 +170,7 @@ Below are a few popular configurations for common styling tools to get you start
           "style-loader",
           "css-loader",
           {
-            loader: "less-loader"
+            loader: "less-loader",
             options: { implementation: require.resolve("less") }
           },
         ],


### PR DESCRIPTION
Just add extra commas in order to fix this behavior.

<img width="532" alt="Screenshot 2023-12-10 at 16 38 28" src="https://github.com/storybookjs/addon-styling-webpack/assets/56846676/c8592c8a-dfd3-4ba0-8869-5002671e8f1c">
